### PR TITLE
Hotfix audioplayer

### DIFF
--- a/add/data/xql/getAudioPlayer.xql
+++ b/add/data/xql/getAudioPlayer.xql
@@ -30,7 +30,7 @@ let $docUri := if(contains($uri, '#')) then(substring-before($uri, '#')) else($u
 let $doc := eutil:getDoc($docUri)
 let $expressionRef := $doc//mei:meiHead/mei:fileDesc/mei:sourceDesc/mei:source/mei:relationList/mei:relation[@rel='isEmbodimentOf']/@target
 let $artist := doc('xmldb:exist:///db/apps/contents/edition/freidi-work.xml')//id(substring-after($expressionRef,'#'))/mei:titleStmt/mei:title/mei:persName
-let $album := $doc//mei:meiHead/mei:fileDesc/mei:sourceDesc/mei:source/mei:titleStmt/mei:title/text()
+let $album := $doc//mei:meiHead/mei:fileDesc/mei:sourceDesc/mei:source/mei:titleStmt/mei:title[1]/text()
 let $albumCoverSurfaceID := substring-after($doc//mei:meiHead/mei:fileDesc/mei:sourceDesc/mei:source/mei:physDesc/mei:titlePage/@facs,'#')
 let $albumCover := '../../../contents/audioSources/' || $doc//id($albumCoverSurfaceID)/mei:graphic/@target
                             

--- a/add/data/xql/getAudioPlayer.xql
+++ b/add/data/xql/getAudioPlayer.xql
@@ -32,7 +32,7 @@ let $expressionRef := $doc//mei:meiHead/mei:fileDesc/mei:sourceDesc/mei:source/m
 let $artist := doc('xmldb:exist:///db/apps/contents/edition/freidi-work.xml')//id(substring-after($expressionRef,'#'))/mei:titleStmt/mei:title/mei:persName
 let $album := $doc//mei:meiHead/mei:fileDesc/mei:sourceDesc/mei:source/mei:titleStmt/mei:title/text()
 let $albumCoverSurfaceID := substring-after($doc//mei:meiHead/mei:fileDesc/mei:sourceDesc/mei:source/mei:physDesc/mei:titlePage/@facs,'#')
-let $albumCover := '../../../contents/audioSources/' || $doc//id($albumCoverSurfaceID)/mei:graphic/@target
+let $albumCover := '../../../contents/audioSources/' || $doc//id($albumCoverSurfaceID)/mei:graphic/@target
                             
 (: TODO: Prüfen, ob die Pfade relativ sind :)
 


### PR DESCRIPTION
* a vertical tab somehow entered the code of getAudioPlayer.xql this rendered the resulting output invalid XML and made the request fail; this PR fixes this error
* additionally for the album title only the first title will be evaluated after this PR, as multiple titles make the xql fail
